### PR TITLE
Merge upstream changes and fix bug where cache objects are always unlinked

### DIFF
--- a/Dockerfile.memcached
+++ b/Dockerfile.memcached
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+                gcc \
+                make \
+                autoconf \
+                gperf \
+                memcached \
+                libmemcached-dev \
+                zlib1g-dev \
+        && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash ccache
+USER ccache
+WORKDIR /home/ccache
+COPY --chown=ccache . .
+
+RUN ./autogen.sh \
+        && ./configure --enable-memcached \
+        && make \
+        && make test

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -543,8 +543,7 @@ NOTE: In previous versions of ccache, *CCACHE_TEMPDIR* had to be on the same
     unifier changes the hash, so cached compilations produced when the unifier
     is enabled cannot be reused when the unifier is disabled, and vice versa.
     Enabling the unifier may result in incorrect line number information in
-    compiler warning messages and expansions of the *\_\_LINE__* macro. Also
-    note that enabling the unifier implies turning off the direct mode.
+    compiler warning messages and expansions of the *\_\_LINE__* macro.
 
 
 Cache size management
@@ -753,7 +752,6 @@ The direct mode will be disabled if any of the following holds:
 * the configuration setting *direct_mode* is false
 * a modification time of one of the include files is too new (needed to avoid a
   race condition)
-* the unifier is enabled (the configuration setting *unify* is true)
 * a compiler option not supported by the direct mode is used:
 ** a *-Wp,_X_* compiler option other than *-Wp,-MD,_path_*,
    *-Wp,-MMD,_path_* and *-Wp,-D_define_*

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -491,7 +491,7 @@ when compiling preprocessed source code.
 *file_stat_matches*::
     ccache normally examines a file's contents to determine whether it matches
     the cached version. With this option set, ccache will consider a file as
-    matching its cached version if the sizes, mtimes and ctimes match.
+    matching its cached version if the mtimes and ctimes match.
 *include_file_ctime*::
     By default, ccache also will not cache a file if it includes a header whose
     ctime is too new. This option disables that check.

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -17,6 +17,8 @@ New features and improvements
 
 - ccache should now work with distcc's ``pump'' wrapper.
 
+- The optional unifier is no longer disabled when the direct mode is enabled.
+
 
 ccache 3.3.5
 ------------

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -16,6 +16,8 @@ Bug fixes
 - Fixed matching of directories in the `ignore_headers_in_manifest`
   configuration option.
 
+- Fixed detection of missing argument to `-opt`/`--options-file`.
+
 
 ccache 3.3.4
 ------------

--- a/ccache.c
+++ b/ccache.c
@@ -560,9 +560,9 @@ remember_include_file(char *path, struct mdfour *cpp_hash, bool system)
 		}
 	}
 
-	// The comparison using >= is intentional, due to a possible race
-	// between starting compilation and writing the include file.
-	// See https://github.com/ccache/ccache/blob/master/MANUAL.txt
+	// The comparison using >= is intentional, due to a possible race between
+	// starting compilation and writing the include file. See also the notes
+	// under "Performance" in MANUAL.txt.
 	if (!(conf->sloppiness & SLOPPY_INCLUDE_FILE_MTIME)
 	    && st.st_mtime >= time_of_compilation) {
 		cc_log("Include file %s too new", path);

--- a/ccache.c
+++ b/ccache.c
@@ -600,9 +600,9 @@ remember_include_file(char *path, struct mdfour *cpp_hash, bool system)
 		}
 	}
 
-	// The comparison using >= is intentional, due to a possible race
-	// between starting compilation and writing the include file.
-	// See https://github.com/ccache/ccache/blob/master/MANUAL.txt
+	// The comparison using >= is intentional, due to a possible race between
+	// starting compilation and writing the include file. See also the notes
+	// under "Performance" in MANUAL.txt.
 	if (!(conf->sloppiness & SLOPPY_INCLUDE_FILE_MTIME)
 	    && st.st_mtime >= time_of_compilation) {
 		cc_log("Include file %s too new", path);

--- a/ccache.c
+++ b/ccache.c
@@ -81,9 +81,6 @@ char *secondary_config_path = NULL;
 // Current working directory taken from $PWD, or getcwd() if $PWD is bad.
 char *current_working_dir = NULL;
 
-// Print the unified preprocessed source code format, to stdout
-bool unify_print = false;
-
 // The original argument list.
 static struct args *orig_args;
 
@@ -1503,16 +1500,15 @@ get_object_name_from_cpp(struct args *args, struct mdfour *hash)
 	}
 
 	if (conf->unify) {
-		char *print = getenv("CCACHE_UNIFY_PRINT");
-		unify_print = print != NULL ? true : false;
-
 		// When we are doing the unifying tricks we need to include the input file
 		// name in the hash to get the warnings right.
 		hash_delimiter(hash, "unifyfilename");
 		hash_string(hash, input_file);
 
 		hash_delimiter(hash, "unifycpp");
-		if (unify_hash(hash, path_stdout, unify_print) != 0) {
+
+		bool debug_unify = getenv("CCACHE_DEBUG_UNIFY");
+		if (unify_hash(hash, path_stdout, debug_unify) != 0) {
 			stats_update(STATS_ERROR);
 			cc_log("Failed to unify %s", path_stdout);
 			failed();

--- a/ccache.c
+++ b/ccache.c
@@ -560,12 +560,16 @@ remember_include_file(char *path, struct mdfour *cpp_hash, bool system)
 		}
 	}
 
+	// The comparison using >= is intentional, due to a possible race
+	// between starting compilation and writing the include file.
+	// See https://github.com/ccache/ccache/blob/master/MANUAL.txt
 	if (!(conf->sloppiness & SLOPPY_INCLUDE_FILE_MTIME)
 	    && st.st_mtime >= time_of_compilation) {
 		cc_log("Include file %s too new", path);
 		goto failure;
 	}
 
+	// The same >= logic as above applies to the change time of the file.
 	if (!(conf->sloppiness & SLOPPY_INCLUDE_FILE_CTIME)
 	    && st.st_ctime >= time_of_compilation) {
 		cc_log("Include file %s ctime too new", path);

--- a/ccache.c
+++ b/ccache.c
@@ -2167,8 +2167,8 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 
 		// Handle cuda "-optf" and "--options-file" argument.
 		if (str_eq(argv[i], "-optf") || str_eq(argv[i], "--options-file")) {
-			if (i > argc) {
-				cc_log("Expected argument after -optf/--options-file");
+			if (i == argc - 1) {
+				cc_log("Expected argument after %s", argv[i]);
 				stats_update(STATS_ARGS);
 				result = false;
 				goto out;
@@ -2269,7 +2269,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		// Special handling for -x: remember the last specified language before the
 		// input file and strip all -x options from the arguments.
 		if (str_eq(argv[i], "-x")) {
-			if (i == argc-1) {
+			if (i == argc - 1) {
 				cc_log("Missing argument to %s", argv[i]);
 				stats_update(STATS_ARGS);
 				result = false;
@@ -2290,7 +2290,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 
 		// We need to work out where the output was meant to go.
 		if (str_eq(argv[i], "-o")) {
-			if (i == argc-1) {
+			if (i == argc - 1) {
 				cc_log("Missing argument to %s", argv[i]);
 				stats_update(STATS_ARGS);
 				result = false;
@@ -2353,7 +2353,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			bool separate_argument = (strlen(argv[i]) == 3);
 			if (separate_argument) {
 				// -MF arg
-				if (i >= argc - 1) {
+				if (i == argc - 1) {
 					cc_log("Missing argument to %s", argv[i]);
 					stats_update(STATS_ARGS);
 					result = false;
@@ -2383,7 +2383,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 			char *relpath;
 			if (strlen(argv[i]) == 3) {
 				// -MQ arg or -MT arg
-				if (i >= argc - 1) {
+				if (i == argc - 1) {
 					cc_log("Missing argument to %s", argv[i]);
 					stats_update(STATS_ARGS);
 					result = false;
@@ -2500,7 +2500,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		}
 
 		if (str_eq(argv[i], "--serialize-diagnostics")) {
-			if (i >= argc - 1) {
+			if (i == argc - 1) {
 				cc_log("Missing argument to %s", argv[i]);
 				stats_update(STATS_ARGS);
 				result = false;
@@ -2590,7 +2590,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		// to get better hit rate. A secondary effect is that paths in the standard
 		// error output produced by the compiler will be normalized.
 		if (compopt_takes_path(argv[i])) {
-			if (i == argc-1) {
+			if (i == argc - 1) {
 				cc_log("Missing argument to %s", argv[i]);
 				stats_update(STATS_ARGS);
 				result = false;
@@ -2642,7 +2642,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 
 		// Options that take an argument.
 		if (compopt_takes_arg(argv[i])) {
-			if (i == argc-1) {
+			if (i == argc - 1) {
 				cc_log("Missing argument to %s", argv[i]);
 				stats_update(STATS_ARGS);
 				result = false;

--- a/ccache.c
+++ b/ccache.c
@@ -600,12 +600,16 @@ remember_include_file(char *path, struct mdfour *cpp_hash, bool system)
 		}
 	}
 
+	// The comparison using >= is intentional, due to a possible race
+	// between starting compilation and writing the include file.
+	// See https://github.com/ccache/ccache/blob/master/MANUAL.txt
 	if (!(conf->sloppiness & SLOPPY_INCLUDE_FILE_MTIME)
 	    && st.st_mtime >= time_of_compilation) {
 		cc_log("Include file %s too new", path);
 		goto failure;
 	}
 
+	// The same >= logic as above applies to the change time of the file.
 	if (!(conf->sloppiness & SLOPPY_INCLUDE_FILE_CTIME)
 	    && st.st_ctime >= time_of_compilation) {
 		cc_log("Include file %s ctime too new", path);

--- a/ccache.c
+++ b/ccache.c
@@ -81,6 +81,9 @@ char *secondary_config_path = NULL;
 // Current working directory taken from $PWD, or getcwd() if $PWD is bad.
 char *current_working_dir = NULL;
 
+// Print the unified preprocessed source code format, to stdout
+bool unify_print = false;
+
 // The original argument list.
 static struct args *orig_args;
 
@@ -1500,13 +1503,16 @@ get_object_name_from_cpp(struct args *args, struct mdfour *hash)
 	}
 
 	if (conf->unify) {
+		char *print = getenv("CCACHE_UNIFY_PRINT");
+		unify_print = print != NULL ? true : false;
+
 		// When we are doing the unifying tricks we need to include the input file
 		// name in the hash to get the warnings right.
 		hash_delimiter(hash, "unifyfilename");
 		hash_string(hash, input_file);
 
 		hash_delimiter(hash, "unifycpp");
-		if (unify_hash(hash, path_stdout) != 0) {
+		if (unify_hash(hash, path_stdout, unify_print) != 0) {
 			stats_update(STATS_ERROR);
 			cc_log("Failed to unify %s", path_stdout);
 			failed();

--- a/ccache.c
+++ b/ccache.c
@@ -3306,11 +3306,6 @@ ccache(int argc, char *argv[])
 	cc_log("Hostname: %s", get_hostname());
 	cc_log("Working directory: %s", get_current_working_dir());
 
-	if (conf->unify) {
-		cc_log("Direct mode disabled because unify mode is enabled");
-		conf->direct_mode = false;
-	}
-
 	conf->limit_multiple = MIN(MAX(conf->limit_multiple, 0.0), 1.0);
 
 	// Arguments (except -E) to send to the preprocessor.

--- a/ccache.c
+++ b/ccache.c
@@ -2326,6 +2326,7 @@ from_fscache(enum fromcache_call_mode mode, bool put_object_in_manifest)
 				put_data_in_cache(data_dep, size_dep, cached_dep);
 			}
 			memccached_free(cache);
+			stat(cached_obj, &st);
 		} else
 #endif
 		return;

--- a/ccache.h
+++ b/ccache.h
@@ -207,7 +207,7 @@ void stats_write(const char *path, struct counters *counters);
 // ----------------------------------------------------------------------------
 // unify.c
 
-int unify_hash(struct mdfour *hash, const char *fname);
+int unify_hash(struct mdfour *hash, const char *fname, bool print);
 
 // ----------------------------------------------------------------------------
 // exitfn.c

--- a/manifest.c
+++ b/manifest.c
@@ -383,10 +383,10 @@ verify_object(struct conf *conf, struct manifest *mf, struct object *obj,
 
 		if (conf->sloppiness & SLOPPY_FILE_STAT_MATCHES) {
 			if (fi->mtime == st->mtime && fi->ctime == st->ctime) {
-				cc_log("size/mtime/ctime hit for %s", path);
+				cc_log("mtime/ctime hit for %s", path);
 				continue;
 			} else {
-				cc_log("size/mtime/ctime miss for %s", path);
+				cc_log("mtime/ctime miss for %s", path);
 			}
 		}
 

--- a/unify.c
+++ b/unify.c
@@ -29,6 +29,8 @@
 
 #include "ccache.h"
 
+static bool print_unified = true;
+
 static const char *const s_tokens[] = {
 	"...", ">>=", "<<=", "+=", "-=", "*=", "/=", "%=", "&=", "^=",
 	"|=",  ">>",  "<<",  "++", "--", "->", "&&", "||", "<=", ">=",
@@ -108,6 +110,9 @@ pushchar(struct mdfour *hash, unsigned char c)
 	if (c == 0) {
 		if (len > 0) {
 			hash_buffer(hash, (char *)buf, len);
+			if (print_unified) {
+				printf("%.*s", (int) len, buf);
+			}
 			len = 0;
 		}
 		hash_buffer(hash, NULL, 0);
@@ -117,6 +122,9 @@ pushchar(struct mdfour *hash, unsigned char c)
 	buf[len++] = c;
 	if (len == 64) {
 		hash_buffer(hash, (char *)buf, len);
+		if (print_unified) {
+			printf("%.*s", (int) len, buf);
+		}
 		len = 0;
 	}
 }
@@ -238,7 +246,7 @@ unify(struct mdfour *hash, unsigned char *p, size_t size)
 // Hash a file that consists of preprocessor output, but remove any line number
 // information from the hash.
 int
-unify_hash(struct mdfour *hash, const char *fname)
+unify_hash(struct mdfour *hash, const char *fname, bool print)
 {
 	char *data;
 	size_t size;
@@ -246,6 +254,7 @@ unify_hash(struct mdfour *hash, const char *fname)
 		stats_update(STATS_PREPROCESSOR);
 		return -1;
 	}
+	print_unified = print;
 	unify(hash, (unsigned char *)data, size);
 	free(data);
 	return 0;

--- a/unify.c
+++ b/unify.c
@@ -1,5 +1,5 @@
 // Copyright (C) 2002 Andrew Tridgell
-// Copyright (C) 2009-2016 Joel Rosdahl
+// Copyright (C) 2009-2017 Joel Rosdahl
 //
 // This program is free software; you can redistribute it and/or modify it
 // under the terms of the GNU General Public License as published by the Free
@@ -246,7 +246,7 @@ unify(struct mdfour *hash, unsigned char *p, size_t size)
 // Hash a file that consists of preprocessor output, but remove any line number
 // information from the hash.
 int
-unify_hash(struct mdfour *hash, const char *fname, bool print)
+unify_hash(struct mdfour *hash, const char *fname, bool debug)
 {
 	char *data;
 	size_t size;
@@ -254,7 +254,7 @@ unify_hash(struct mdfour *hash, const char *fname, bool print)
 		stats_update(STATS_PREPROCESSOR);
 		return -1;
 	}
-	print_unified = print;
+	print_unified = debug;
 	unify(hash, (unsigned char *)data, size);
 	free(data);
 	return 0;


### PR DESCRIPTION
First of all, let me thank you for your hard work, this is an awesome solution to ccache sharing.

While testing with the latest HEAD, we noticed that ccache with memcached support stopped working.

After investigating, I discovered that the objects are stored and fetched correctly, but the resulting file is deleted directly after being copied on the disk because the `stat` information wasn't refreshed.

I'm not sure why the tests would not catch this issue (I guess we should fix the tests somehow before you merge this).

I also took the liberty to quickly add a Dockerfile to be able to build + run the tests with memcached support enabled.